### PR TITLE
Modify docker-compose,build by dockerfile -> image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
 version: "3.8"
 services:
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
+    image: codingold/filmfinder-app-frontend:latest
     container_name: frontend
     ports:
       - "3000:80"
@@ -13,9 +11,7 @@ services:
       - app-network
 
   backend:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
+    image: codingold/filmfinder-app-backend:latest
     container_name: backend
     ports:
       - "8080:8080"


### PR DESCRIPTION
docker-compose파일에서 로컬의 dockerfile을 빌드하며,
컨테이너가 생성되지 않는 오류가 발생함. 각각 이미지를 빌드하면 정상 작동하는 것으로 보아, dockerfile를 빌드하여 생긴문제로 파악함.
dockerhub에서 받아온 이미지가 빌드되도록 docker-compose파일 수정